### PR TITLE
FIX: title incomplete if has spaces between words

### DIFF
--- a/src/new.ts
+++ b/src/new.ts
@@ -34,7 +34,7 @@ export default function () {
             Messages.noValueError();
             return;
         }
-        options.Title = value;
+        options.Title = `"{value}"`;
         runCommand(['new', options.Layout, options.Title])
     });
 };


### PR DESCRIPTION
For example, when using `hexo new` with title `my new post`, the file created is named `post` which is always the last word. Only if I quote the title with `"`, the name will be complete.

This PR tries to always add quotes to avoid this problem.